### PR TITLE
Globally set ToastrConfig using forRoot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,16 @@ tapToDismiss: boolean = true; // close on click
 ```
 
 ### Override default settings
-NEW FOR VERSION > 3 global overrides must be done inside a component.
-Inject ToastrConfig, typically in your root component, and customize the values of its properties in order to provide default values for all the toasts in the application.
+NEW FOR VERSION > 3
+Option 1: Pass values to ToastrModule.forRoot
+```typescript
+// your NgModule
+imports: [
+  ToastrModule.forRoot({timeOut: 0}),
+], 
+```
+
+Option 2: Inject ToastrConfig, typically in your root component, and customize the values.
 ```typescript
 import { ToastrConfig } from 'toastr-ng2';
 import { Component } from '@angular/core';
@@ -118,15 +126,10 @@ export class AppComponent {
 ### individual toast settings
 success, error, info, warning take ```(message, title, ToastConfig)``` pass a ToastConfig object to replace several default settings.
 ```typescript
+// OPTIONAL: import the ToastConfig interface
 import { ToastConfig } from 'toastr-ng2';
 
-let errorConfig = new ToastConfig();
-// display until dismissed
-errorConfig.timeOut = 0;
-
-// OR pass config as an object
-errorConfig = new ToastConfig({timeOut: 10000});
-
+const errorConfig: ToastConfig = {timeOut: 10000};
 this.toastrService.error('everything is broken', 'title is optional', errorConfig);
 ```
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -179,6 +179,7 @@
               <button (click)="clearLastToast()" class="btn btn-secondary">Clear Last Toast</button>
               <button (click)="clearToasts()" class="btn btn-secondary">Clear All Toasts</button>
               <button (click)="openPinkToast()" class="btn btn-pink">Custom Pink Toast</button>
+              <button (click)="openToastWithCustomConfig()" class="btn btn-warning">Toast With Custom Config</button>
             </div>
           </div>
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -89,6 +89,11 @@ export class AppComponent {
       this.lastInserted.push(inserted.toastId);
     }
   }
+  openToastWithCustomConfig() {
+    this.toastrService.success('Toast with a custom config', '', { timeOut: 7500, progressBar: true, closeButton: true });
+    this.toastrService.warning('Another toast with a custom config', '', { timeOut: 3500, closeButton: true });
+    this.toastrService.error('Another toast with a custom config', '', { extendedTimeOut: 2000, progressBar: true });
+  }
   clearToasts() {
     this.toastrService.clear();
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,8 +3,9 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
-import { ToastrModule } from '../lib/toastr';
+import { ToastrModule, ToastConfig } from '../lib/toastr';
 import { PinkToast } from './pink.toast';
+
 
 @NgModule({
   declarations: [
@@ -14,7 +15,6 @@ import { PinkToast } from './pink.toast';
   imports: [
     BrowserModule,
     FormsModule,
-    ToastrModule,
   ],
   entryComponents: [PinkToast],
   providers: [],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,9 @@ import { AppComponent } from './app.component';
 import { ToastrModule, ToastConfig } from '../lib/toastr';
 import { PinkToast } from './pink.toast';
 
+// const toastConfig: ToastConfig = {
+//   timeOut: 10000
+// }
 
 @NgModule({
   declarations: [
@@ -15,6 +18,7 @@ import { PinkToast } from './pink.toast';
   imports: [
     BrowserModule,
     FormsModule,
+    ToastrModule.forRoot(),
   ],
   entryComponents: [PinkToast],
   providers: [],

--- a/src/lib/toastr-config.ts
+++ b/src/lib/toastr-config.ts
@@ -54,6 +54,11 @@ export class ToastrConfig implements ToastConfig {
   preventDuplicates: boolean = false;
 
   constructor(config: ToastConfig = {}) {
+    this.overrideDefaultValues(config);
+  }
+
+
+  private overrideDefaultValues(config: ToastConfig) {
     this.closeButton = config.closeButton || this.closeButton;
     this.extendedTimeOut = config.extendedTimeOut || this.extendedTimeOut;
     this.onHidden = config.onHidden || this.onHidden;
@@ -68,5 +73,12 @@ export class ToastrConfig implements ToastConfig {
     this.messageClass = config.messageClass || this.messageClass;
     this.tapToDismiss = config.tapToDismiss || this.tapToDismiss;
     this.toastComponent = config.toastComponent || this.toastComponent;
+  }
+
+  public override(config: ToastConfig = {}) {
+    let toastrConfig = Object.create(this);
+    toastrConfig.overrideDefaultValues(config);
+
+    return toastrConfig;
   }
 }

--- a/src/lib/toastr-config.ts
+++ b/src/lib/toastr-config.ts
@@ -2,11 +2,31 @@ import { Injectable, EventEmitter } from '@angular/core';
 
 import { Toast } from './toast-component';
 
+
+export interface ToastConfig {
+  closeButton?: boolean;
+  extendedTimeOut?: number;
+  onHidden?: EventEmitter<any>;
+  onShown?: EventEmitter<any>;
+  onTap?: EventEmitter<any>;
+  progressBar?: boolean;
+  timeOut?: number;
+
+  toastClass?: string;
+  positionClass?: string;
+  titleClass?: string;
+  messageClass?: string;
+  tapToDismiss?: boolean;
+  toastComponent?: any;
+}
+
 /**
- * Configuration for an individual toast.
+ * Global Toast configuration
+ * You can inject this service, typically in your root component, and customize the values of its properties in
+ * order to provide default values for all the timepickers used in the application.
  */
-export class ToastConfig {
-  // shows close button
+@Injectable()
+export class ToastrConfig implements ToastConfig {
   closeButton: boolean = false;
   extendedTimeOut: number = 1000;
   onHidden: EventEmitter<any> = new EventEmitter();
@@ -20,8 +40,20 @@ export class ToastConfig {
   titleClass: string = 'toast-title';
   messageClass: string = 'toast-message';
   tapToDismiss: boolean = true;
-  toastComponent = Toast;
-  constructor(config: any = {}) {
+  toastComponent: any = Toast;
+
+  maxOpened: number = 0;
+  autoDismiss: boolean = false;
+  iconClasses = {
+    error: 'toast-error',
+    info: 'toast-info',
+    success: 'toast-success',
+    warning: 'toast-warning',
+  };
+  newestOnTop: boolean = true;
+  preventDuplicates: boolean = false;
+
+  constructor(config: ToastConfig = {}) {
     this.closeButton = config.closeButton || this.closeButton;
     this.extendedTimeOut = config.extendedTimeOut || this.extendedTimeOut;
     this.onHidden = config.onHidden || this.onHidden;
@@ -36,27 +68,5 @@ export class ToastConfig {
     this.messageClass = config.messageClass || this.messageClass;
     this.tapToDismiss = config.tapToDismiss || this.tapToDismiss;
     this.toastComponent = config.toastComponent || this.toastComponent;
-  }
-}
-
-/**
- * Global Toast configuration
- * You can inject this service, typically in your root component, and customize the values of its properties in
- * order to provide default values for all the timepickers used in the application.
- */
-@Injectable()
-export class ToastrConfig extends ToastConfig {
-  maxOpened: number = 0;
-  autoDismiss: boolean = false;
-  iconClasses = {
-    error: 'toast-error',
-    info: 'toast-info',
-    success: 'toast-success',
-    warning: 'toast-warning',
-  };
-  newestOnTop: boolean = true;
-  preventDuplicates: boolean = false;
-  constructor() {
-    super();
   }
 }

--- a/src/lib/toastr-config.ts
+++ b/src/lib/toastr-config.ts
@@ -2,7 +2,9 @@ import { Injectable, EventEmitter } from '@angular/core';
 
 import { Toast } from './toast-component';
 
-
+/**
+ * Individual Toast Config
+ */
 export interface ToastConfig {
   closeButton?: boolean;
   extendedTimeOut?: number;
@@ -22,8 +24,6 @@ export interface ToastConfig {
 
 /**
  * Global Toast configuration
- * You can inject this service, typically in your root component, and customize the values of its properties in
- * order to provide default values for all the timepickers used in the application.
  */
 @Injectable()
 export class ToastrConfig implements ToastConfig {

--- a/src/lib/toastr-module.ts
+++ b/src/lib/toastr-module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule, ModuleWithProviders, Inject, Optional } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 
@@ -15,10 +15,15 @@ import { Overlay } from './overlay/overlay';
   entryComponents: [Toast],
 })
 export class ToastrModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: ToastrModule, providers: [
-    ToastrConfig,
-    OverlayContainer,
-    Overlay,
-    ToastrService,
-  ]}; }
+  static forRoot(config?: ToastConfig): ModuleWithProviders {
+    return {
+      ngModule: ToastrModule,
+      providers: [
+        { provide: ToastrConfig, useFactory: () => new ToastrConfig(config) },
+        OverlayContainer,
+        Overlay,
+        ToastrService
+      ]
+    };
+  }
 }

--- a/src/lib/toastr-module.ts
+++ b/src/lib/toastr-module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule, ModuleWithProviders, OpaqueToken } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 
@@ -7,6 +7,12 @@ import { ToastrService } from './toastr-service';
 import { ToastConfig, ToastrConfig } from './toastr-config';
 import { OverlayContainer } from './overlay/overlay-container';
 import { Overlay } from './overlay/overlay';
+
+export const TOAST_CONFIG = new OpaqueToken('ToastConfig');
+
+export function provideToastrConfig(config: ToastConfig) {
+  return new ToastrConfig(config);
+}
 
 @NgModule({
   imports: [BrowserModule, CommonModule],
@@ -19,7 +25,8 @@ export class ToastrModule {
     return {
       ngModule: ToastrModule,
       providers: [
-        { provide: ToastrConfig, useFactory: () => new ToastrConfig(config) },
+        { provide: TOAST_CONFIG, useValue: config },
+        { provide: ToastrConfig, useFactory: provideToastrConfig, deps: [TOAST_CONFIG] },
         OverlayContainer,
         Overlay,
         ToastrService

--- a/src/lib/toastr-module.ts
+++ b/src/lib/toastr-module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ModuleWithProviders, Inject, Optional } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 

--- a/src/lib/toastr-service.ts
+++ b/src/lib/toastr-service.ts
@@ -22,7 +22,7 @@ export class ToastrService {
   constructor(
     public toastrConfig: ToastrConfig,
     private overlay: Overlay
-  ) {}
+  ) { }
 
   public success(message: string, title?: string, optionsOverride?: ToastConfig): ActiveToast {
     const type = this.toastrConfig.iconClasses.success;
@@ -73,13 +73,13 @@ export class ToastrService {
     }
     return true;
   }
-  private _findToast(toastId: number): {index: number, activeToast: ActiveToast} {
+  private _findToast(toastId: number): { index: number, activeToast: ActiveToast } {
     for (let i = 0; i < this.toasts.length; i++) {
       if (this.toasts[i].toastId === toastId) {
-        return {index: i, activeToast: this.toasts[i]};
+        return { index: i, activeToast: this.toasts[i] };
       }
     }
-    return {index: null, activeToast: null};
+    return { index: null, activeToast: null };
   }
   private isDuplicate(message: string): boolean {
     for (let i = 0; i < this.toasts.length; i++) {
@@ -94,8 +94,10 @@ export class ToastrService {
     type: string,
     message: string,
     title: string,
-    optionsOverride: ToastConfig = Object.create(this.toastrConfig)
+    optionsOverride?: ToastConfig
   ): ActiveToast {
+    optionsOverride = this.toastrConfig.override(optionsOverride);
+
     // max opened and auto dismiss = true
     if (this.toastrConfig.preventDuplicates && this.isDuplicate(message)) {
       return;


### PR DESCRIPTION
This allows ToastrConfig to be globally configured close to how it was done before.

This is how it would work:
```
import { BrowserModule } from '@angular/platform-browser';
import { NgModule } from '@angular/core';
import { FormsModule } from '@angular/forms';

import { AppComponent } from './app.component';
import { ToastrModule, ToastConfig } from '../lib/toastr';
import { PinkToast } from './pink.toast';

const toastConfig: ToastConfig = {
  timeOut: 10000,
  progressBar: true
};

@NgModule({
  declarations: [
    AppComponent,
    PinkToast,
  ],
  imports: [
    BrowserModule,
    FormsModule,
    ToastrModule.forRoot(toastConfig),
  ],
  entryComponents: [PinkToast],
  providers: [],
  bootstrap: [AppComponent]
})
export class AppModule { }
```

The toastrConfig is optional so that if no global config is wanted, the defaults will be applied.