### PR TITLE
Use rollup to build the toastr.umd.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "private": true,
   "dependencies": {
-    "bootstrap": "^4.0.0-alpha.5",
     "@angular/common": "~2.3.1",
     "@angular/compiler": "~2.3.1",
     "@angular/core": "~2.3.1",
@@ -28,6 +27,7 @@
     "@angular/http": "~2.3.1",
     "@angular/platform-browser": "~2.3.1",
     "@angular/platform-browser-dynamic": "~2.3.1",
+    "bootstrap": "^4.0.0-alpha.5",
     "core-js": "^2.4.1",
     "lodash": "^4.17.2",
     "rxjs": "5.0.0-rc.4",
@@ -49,6 +49,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
     "protractor": "~4.0.13",
+    "rollup": "^0.37.0",
     "ts-node": "1.2.1",
     "tslint": "^4.0.2",
     "typescript": "~2.0.3"

--- a/rollup.js
+++ b/rollup.js
@@ -1,40 +1,14 @@
-const webpack = require('webpack');
-
-function webpackCallBack(taskName) {
-  return function(err, stats) {
-    if (err) throw err;
-    console.log('Rollup Finished');
+export default {
+  entry: './deploy/toastr.js',
+  dest: './deploy/toastr.umd.js',
+  format: 'umd',
+  moduleName: 'toastrng2',
+  globals: {
+    '@angular/core': 'ng.core',
+    '@angular/compiler': 'ng.compiler',
+    '@angular/platform-browser': 'ng.platformBrowser',
+    '@angular/http': 'ng.http',
+    'rxjs/Observable': 'Rx',
+    'rxjs/Subject': 'Rx'
   }
-}
-
-function ngExternal(ns) {
-    const ng2Ns = `@angular/${ns}`;
-    return {root: ['ng', ns], commonjs: ng2Ns, commonjs2: ng2Ns, amd: ng2Ns};
-  }
-
-function rxjsExternal(context, request, cb) {
-  if (/^rxjs\/add\/observable\//.test(request)) {
-    return cb(null, {root: ['Rx', 'Observable'], commonjs: request, commonjs2: request, amd: request});
-  } else if (/^rxjs\/add\/operator\//.test(request)) {
-    return cb(null, {root: ['Rx', 'Observable', 'prototype'], commonjs: request, commonjs2: request, amd: request});
-  } else if (/^rxjs\//.test(request)) {
-    return cb(null, {root: ['Rx'], commonjs: request, commonjs2: request, amd: request});
-  }
-  cb();
-}
-
-webpack(
-  {
-    entry: './deploy/toastr.js',
-    output: {filename: './deploy/toastr.umd.js', library: 'toastrng2', libraryTarget: 'umd'},
-    devtool: 'source-map',
-    externals: [
-      {
-        '@angular/core': ngExternal('core'),
-        '@angular/common': ngExternal('common'),
-        '@angular/forms': ngExternal('forms')
-      },
-      rxjsExternal
-    ]
-  },
-  webpackCallBack('webpack', ()=>console.log('webpacked')));
+};

--- a/rollup.js
+++ b/rollup.js
@@ -5,10 +5,5 @@ export default {
   moduleName: 'toastrng2',
   globals: {
     '@angular/core': 'ng.core',
-    '@angular/compiler': 'ng.compiler',
-    '@angular/platform-browser': 'ng.platformBrowser',
-    '@angular/http': 'ng.http',
-    'rxjs/Observable': 'Rx',
-    'rxjs/Subject': 'Rx'
   }
 };

--- a/stage-release.sh
+++ b/stage-release.sh
@@ -12,7 +12,7 @@ rm -rf waste
 # compile src directory and create d.ts files
 ./node_modules/.bin/ngc -p ./src/lib/tsconfig.json -d
 # create umd
-node ./rollup.js
+./node_modules/.bin/rollup -c rollup.js
 
 # copy root readme and license to deployment folder
 # for multiple


### PR DESCRIPTION
Pull in rollup to create the toastr.umd.js file for compatibility with systemjs

Solves issues found in #41