### PR TITLE
Remove interfaces so that AoT works with angular >= 2.4.0

### DIFF
--- a/src/lib/toastr-config.ts
+++ b/src/lib/toastr-config.ts
@@ -3,43 +3,26 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { ComponentType } from './portal/portal';
 import { Toast } from './toast-component';
 
-export interface SingleToastConfig {
-  closeButton?: boolean;
-  extendedTimeOut?: number;
-  onHidden?: EventEmitter<any>;
-  onShown?: EventEmitter<any>;
-  onTap?: EventEmitter<any>;
-  progressBar?: boolean;
-  timeOut?: number;
-
-  toastClass?: string;
-  positionClass?: string;
-  titleClass?: string;
-  messageClass?: string;
-  tapToDismiss?: boolean;
-  toastComponent?: ComponentType<any>;
-}
-
 /**
  * Configuration for an individual toast.
  */
-export class ToastConfig implements SingleToastConfig {
+export class ToastConfig {
   // shows close button
-  closeButton = false;
-  extendedTimeOut = 1000;
-  onHidden = new EventEmitter();
-  onShown = new EventEmitter();
-  onTap = new EventEmitter();
-  progressBar = false;
-  timeOut = 5000;
+  closeButton?: boolean = false;
+  extendedTimeOut?: number = 1000;
+  onHidden?: EventEmitter<any> = new EventEmitter();
+  onShown?: EventEmitter<any> = new EventEmitter();
+  onTap?: EventEmitter<any> = new EventEmitter();
+  progressBar?: boolean = false;
+  timeOut?: number = 5000;
 
-  toastClass = 'toast';
-  positionClass = 'toast-top-right';
-  titleClass = 'toast-title';
-  messageClass = 'toast-message';
-  tapToDismiss = true;
-  toastComponent = Toast;
-  constructor(config: GlobalToastConfig = {}) {
+  toastClass?: string = 'toast';
+  positionClass?: string = 'toast-top-right';
+  titleClass?: string = 'toast-title';
+  messageClass?: string = 'toast-message';
+  tapToDismiss?: boolean = true;
+  toastComponent?: ComponentType<any> = Toast;
+  constructor(config: ToastConfig = {}) {
     this.closeButton = config.closeButton || this.closeButton;
     if (config.extendedTimeOut === 0) {
       this.extendedTimeOut = config.extendedTimeOut;
@@ -65,35 +48,30 @@ export class ToastConfig implements SingleToastConfig {
   }
 }
 
-export interface GlobalToastConfig extends SingleToastConfig {
-  maxOpened?: number;
-  autoDismiss?: boolean;
-  iconClasses?: {
-    error?: string,
-    info?: string,
-    success?: string,
-    warning?: string,
-  };
-  newestOnTop?: boolean;
-  preventDuplicates?: boolean;
+@Injectable()
+export class ToastrIconClasses {
+  error?: string;
+  info?: string;
+  success?: string;
+  warning?: string;
 }
 
 /**
  * Global Toast configuration
  */
 @Injectable()
-export class ToastrConfig extends ToastConfig implements GlobalToastConfig {
-  maxOpened = 0;
-  autoDismiss = false;
-  iconClasses = {
+export class ToastrConfig extends ToastConfig {
+  maxOpened?: number = 0;
+  autoDismiss?: boolean = false;
+  iconClasses?: ToastrIconClasses = {
     error: 'toast-error',
     info: 'toast-info',
     success: 'toast-success',
     warning: 'toast-warning',
   };
-  newestOnTop = true;
-  preventDuplicates = false;
-  constructor(config: GlobalToastConfig = {}) {
+  newestOnTop?: boolean = true;
+  preventDuplicates?: boolean = false;
+  constructor(config: ToastrConfig = {}) {
     super(config);
     this.maxOpened = config.maxOpened || this.maxOpened;
     this.autoDismiss = config.autoDismiss || this.autoDismiss;

--- a/src/lib/toastr-module.ts
+++ b/src/lib/toastr-module.ts
@@ -4,13 +4,13 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { Toast } from './toast-component';
 import { ToastrService } from './toastr-service';
-import { ToastConfig, ToastrConfig, GlobalToastConfig } from './toastr-config';
+import { ToastConfig, ToastrConfig } from './toastr-config';
 import { OverlayContainer } from './overlay/overlay-container';
 import { Overlay } from './overlay/overlay';
 
 export const TOAST_CONFIG = new OpaqueToken('ToastConfig');
 
-export function provideToastrConfig(config: GlobalToastConfig) {
+export function provideToastrConfig(config: ToastrConfig) {
   return new ToastrConfig(config);
 }
 
@@ -21,7 +21,7 @@ export function provideToastrConfig(config: GlobalToastConfig) {
   entryComponents: [Toast],
 })
 export class ToastrModule {
-  static forRoot(config?: GlobalToastConfig): ModuleWithProviders {
+  static forRoot(config?: ToastrConfig): ModuleWithProviders {
     return {
       ngModule: ToastrModule,
       providers: [

--- a/src/lib/toastr-service.ts
+++ b/src/lib/toastr-service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Overlay } from './overlay/overlay';
 import { OverlayRef } from './overlay/overlay-ref';
 import { ComponentPortal } from './portal/portal';
-import { ToastConfig, ToastrConfig, SingleToastConfig } from './toastr-config';
+import { ToastConfig, ToastrConfig } from './toastr-config';
 
 export interface ActiveToast {
   toastId: number;
@@ -22,26 +22,26 @@ export class ToastrService {
   constructor(
     public toastrConfig: ToastrConfig,
     private overlay: Overlay
-  ) {}
+  ) { }
 
-  public success(message: string, title?: string, optionsOverride?: SingleToastConfig |  ToastConfig): ActiveToast {
+  public success(message: string, title?: string, optionsOverride?: ToastConfig): ActiveToast {
     const type = this.toastrConfig.iconClasses.success;
     return this._buildNotification(type, message, title, this.createToastConfig(optionsOverride));
   }
-  public error(message: string, title?: string, optionsOverride?: SingleToastConfig |  ToastConfig): ActiveToast {
+  public error(message: string, title?: string, optionsOverride?: ToastConfig): ActiveToast {
     const type = this.toastrConfig.iconClasses.error;
     return this._buildNotification(type, message, title, this.createToastConfig(optionsOverride));
   }
-  public info(message: string, title?: string, optionsOverride?: SingleToastConfig |  ToastConfig): ActiveToast {
+  public info(message: string, title?: string, optionsOverride?: ToastConfig): ActiveToast {
     const type = this.toastrConfig.iconClasses.info;
     return this._buildNotification(type, message, title, this.createToastConfig(optionsOverride));
   }
-  public warning(message: string, title?: string, optionsOverride?: SingleToastConfig |  ToastConfig): ActiveToast {
+  public warning(message: string, title?: string, optionsOverride?: ToastConfig): ActiveToast {
     const type = this.toastrConfig.iconClasses.warning;
     return this._buildNotification(type, message, title, this.createToastConfig(optionsOverride));
   }
-  createToastConfig(optionsOverride: SingleToastConfig |  ToastConfig): ToastConfig {
-    if (!optionsOverride)  {
+  createToastConfig(optionsOverride: ToastConfig): ToastConfig {
+    if (!optionsOverride) {
       return Object.create(this.toastrConfig);
     }
     if (optionsOverride instanceof ToastConfig) {
@@ -82,7 +82,7 @@ export class ToastrService {
     }
     return true;
   }
-  private _findToast(toastId: number): {index: number, activeToast: ActiveToast} {
+  private _findToast(toastId: number): { index: number, activeToast: ActiveToast } {
     for (let i = 0; i < this.toasts.length; i++) {
       if (this.toasts[i].toastId === toastId) {
         return { index: i, activeToast: this.toasts[i] };


### PR DESCRIPTION
This is to fix issues with angular >= 2.4.0 found in #44 and also simplifies the toastr-config.ts file by removing the interfaces and making the properties on the classes optional.

Not exactly sure why the interface GlobalToastConfig is causing issues but this seems to fix it.